### PR TITLE
chore: pin node and npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,5 +79,9 @@
     "hooks": {
       "pre-commit": "pretty-quick --staged"
     }
+  },
+  "engines": {
+    "node": "=16.20.2",
+    "npm": "=7.5.6"
   }
 }


### PR DESCRIPTION
Project is utter outdated. Only way I found to reinstall it was to used the engine specified.

