### PR TITLE
chore: status bar color light for Android

### DIFF
--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -7,6 +7,10 @@
 			"launchAutoHide": false,
 			"backgroundColor": "#fbf8f3",
 			"androidScaleType": "CENTER_CROP"
+		},
+		"StatusBar": {
+			"overlaysWebView": false,
+			"style": "LIGHT"
 		}
 	},
 	"cordova": {}

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -13,6 +13,13 @@ const config: CapacitorConfig = {
       backgroundColor: '#fbf8f3',
       androidScaleType: 'CENTER_CROP',
     },
+    StatusBar: {
+      overlaysWebView: false,
+      style: 'LIGHT',
+      // Waiting on bug fix for issue to be merged:
+      // https://github.com/ionic-team/capacitor-plugins/issues/2341
+      // backgroundColor: '#fbf8f3',
+    },
   },
   cordova: {},
 };

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -7,6 +7,10 @@
 			"launchAutoHide": false,
 			"backgroundColor": "#fbf8f3",
 			"androidScaleType": "CENTER_CROP"
+		},
+		"StatusBar": {
+			"overlaysWebView": false,
+			"style": "LIGHT"
 		}
 	},
 	"cordova": {},


### PR DESCRIPTION
Capacitor status bar is buggy and do no inherits background. This does not resolve the issue but nevertheless.

https://github.com/ionic-team/capacitor-plugins/issues/2341

<img width="1533" height="1034" alt="Capture d’écran 2026-01-02 à 11 24 53" src="https://github.com/user-attachments/assets/b5b4e240-6262-4702-8932-6adfc41022ba" />
